### PR TITLE
:page_facing_up:: Notifiacation에 Reservation연관 관계 null로 하기

### DIFF
--- a/src/main/java/ohsoontaxi/backend/domain/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/ohsoontaxi/backend/domain/notification/domain/repository/NotificationRepository.java
@@ -14,4 +14,8 @@ import java.util.Optional;
 public interface NotificationRepository extends JpaRepository<Notification, Long>, CustomNotificationRepository{
 
     Optional<Notification> findByReservation(Reservation reservation);
+
+    @Modifying(flushAutomatically = true)
+    @Query("update Notification n set n.reservation = null where n.reservation.id = :reservationId")
+    void changeReservationNull(@Param("reservationId") Long reservationId);
 }

--- a/src/main/java/ohsoontaxi/backend/domain/notification/service/NotificationUtils.java
+++ b/src/main/java/ohsoontaxi/backend/domain/notification/service/NotificationUtils.java
@@ -6,12 +6,12 @@ import ohsoontaxi.backend.domain.reservation.domain.Reservation;
 import ohsoontaxi.backend.domain.user.domain.User;
 
 public interface NotificationUtils {
+    void changeReservationNull(Long reservationId);
     void sendNotificationNoUser(
             User user,
             Reservation reservation,
             TitleMessage titleMessage,
             ContentMessage contentMessage);
-
     void sendNotificationAll(
             Reservation reservation,
             TitleMessage titleMessage,

--- a/src/main/java/ohsoontaxi/backend/domain/notification/service/NotificationUtilsImpl.java
+++ b/src/main/java/ohsoontaxi/backend/domain/notification/service/NotificationUtilsImpl.java
@@ -36,6 +36,12 @@ public class NotificationUtilsImpl implements NotificationUtils{
 
     @Override
     @Transactional
+    public void changeReservationNull(Long reservationId) {
+        notificationRepository.changeReservationNull(reservationId);
+    }
+
+    @Override
+    @Transactional
     public void sendNotificationNoUser(User user, Reservation reservation, TitleMessage titleMessage,
                                        ContentMessage contentMessage) {
         List<DeviceToken> deviceTokens = notificationRepository.findTokenByReservationIdNeUserId(


### PR DESCRIPTION
- Reservation이 삭제될 때 Notification은 삭제되면 안되기 때문에 연관관계를 벌크 연산으로 null로 만든다.