### PR TITLE
refactor : 인가 코드 요청 및 토큰 요청 로직

### DIFF
--- a/src/main/java/ohsoontaxi/backend/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/presentation/CredentialController.java
@@ -7,11 +7,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import ohsoontaxi.backend.domain.credential.presentation.dto.request.OauthCodeRequest;
 import ohsoontaxi.backend.domain.credential.presentation.dto.request.RegisterRequest;
 import ohsoontaxi.backend.domain.credential.presentation.dto.request.TokenRefreshRequest;
-import ohsoontaxi.backend.domain.credential.presentation.dto.response.AccessTokenDto;
-import ohsoontaxi.backend.domain.credential.presentation.dto.response.AuthTokensResponse;
-import ohsoontaxi.backend.domain.credential.presentation.dto.response.AvailableRegisterResponse;
+import ohsoontaxi.backend.domain.credential.presentation.dto.response.*;
 import ohsoontaxi.backend.domain.credential.service.CredentialService;
 import ohsoontaxi.backend.domain.credential.service.OauthProvider;
 import org.springframework.web.bind.annotation.*;
@@ -32,6 +31,18 @@ public class CredentialController {
     public AccessTokenDto login(@PathVariable("userId") Long userId){
         AccessTokenDto result = credentialService.login(userId);
         return result;
+    }
+
+    @Operation(summary = "카카오 인가 코드 받기 (서버 테스트용)")
+    @GetMapping("/oauth/link/kakao")
+    public OauthLoginLinkResponse getKakaoOauthLink() {
+        return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.KAKAO));
+    }
+
+    @Operation(summary = "구글 인가 코드 받기 (서버 테스트용)")
+    @GetMapping("/oauth/link/google")
+    public OauthLoginLinkResponse getGoogleOauthLink() {
+        return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.GOOGLE));
     }
 
     @Operation(summary = "Id Token 검증")

--- a/src/main/java/ohsoontaxi/backend/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/presentation/CredentialController.java
@@ -39,10 +39,22 @@ public class CredentialController {
         return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.KAKAO));
     }
 
+    @Operation(summary = "카카오 accessToken, idToken 받기 (서버 테스트용)")
+    @GetMapping("/oauth/kakao")
+    public AfterOauthResponse kakaoAuth(OauthCodeRequest oauthCodeRequest) {
+        return credentialService.getTokenToCode(OauthProvider.KAKAO, oauthCodeRequest.getCode());
+    }
+
     @Operation(summary = "구글 인가 코드 받기 (서버 테스트용)")
     @GetMapping("/oauth/link/google")
     public OauthLoginLinkResponse getGoogleOauthLink() {
         return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.GOOGLE));
+    }
+
+    @Operation(summary = "구글 accessToken, idToken 받기 (서버 테스트용)")
+    @GetMapping("/oauth/google")
+    public AfterOauthResponse googleAuth(OauthCodeRequest oauthCodeRequest) {
+        return credentialService.getTokenToCode(OauthProvider.GOOGLE, oauthCodeRequest.getCode());
     }
 
     @Operation(summary = "Id Token 검증")

--- a/src/main/java/ohsoontaxi/backend/domain/credential/presentation/dto/request/OauthCodeRequest.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/presentation/dto/request/OauthCodeRequest.java
@@ -1,0 +1,10 @@
+package ohsoontaxi.backend.domain.credential.presentation.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OauthCodeRequest {
+    private String code;
+}

--- a/src/main/java/ohsoontaxi/backend/domain/credential/presentation/dto/response/AfterOauthResponse.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/presentation/dto/response/AfterOauthResponse.java
@@ -1,0 +1,11 @@
+package ohsoontaxi.backend.domain.credential.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AfterOauthResponse {
+    private String idToken;
+    private String accessToken;
+}

--- a/src/main/java/ohsoontaxi/backend/domain/credential/presentation/dto/response/OauthLoginLinkResponse.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/presentation/dto/response/OauthLoginLinkResponse.java
@@ -1,0 +1,11 @@
+package ohsoontaxi.backend.domain.credential.presentation.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OauthLoginLinkResponse {
+
+    private String link;
+}

--- a/src/main/java/ohsoontaxi/backend/domain/credential/presentation/dto/response/OauthTokenInfoDto.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/presentation/dto/response/OauthTokenInfoDto.java
@@ -1,0 +1,11 @@
+package ohsoontaxi.backend.domain.credential.presentation.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OauthTokenInfoDto {
+    private String idToken;
+    private String accessToken;
+}

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/CredentialService.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/CredentialService.java
@@ -6,9 +6,7 @@ import ohsoontaxi.backend.domain.credential.domain.RefreshTokenRedisEntity;
 import ohsoontaxi.backend.domain.credential.domain.repository.RefreshTokenRedisEntityRepository;
 import ohsoontaxi.backend.domain.credential.exception.RefreshTokenExpiredException;
 import ohsoontaxi.backend.domain.credential.presentation.dto.request.RegisterRequest;
-import ohsoontaxi.backend.domain.credential.presentation.dto.response.AccessTokenDto;
-import ohsoontaxi.backend.domain.credential.presentation.dto.response.AuthTokensResponse;
-import ohsoontaxi.backend.domain.credential.presentation.dto.response.AvailableRegisterResponse;
+import ohsoontaxi.backend.domain.credential.presentation.dto.response.*;
 import ohsoontaxi.backend.domain.email.domain.EmailMessage;
 import ohsoontaxi.backend.domain.email.exception.NotEmailApprovedException;
 import ohsoontaxi.backend.domain.email.service.EmailUtils;
@@ -48,25 +46,9 @@ public class CredentialService {
         return new AccessTokenDto(accessToken);
     }
 
-    private String generateRefreshToken(Long userId) {
-        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
-        Long tokenExpiredAt = jwtTokenProvider.getRefreshTokenTTlSecond();
-        RefreshTokenRedisEntity build =
-                RefreshTokenRedisEntity.builder()
-                        .id(userId.toString())
-                        .ttl(tokenExpiredAt)
-                        .refreshToken(refreshToken)
-                        .build();
-        refreshTokenRedisEntityRepository.save(build);
-        return refreshToken;
-    }
-
-    private Boolean checkUserCanRegister(
-            OIDCDecodePayload oidcDecodePayload, OauthProvider oauthProvider) {
-        Optional<User> user =
-                userRepository.findByOauthIdAndOauthProvider(
-                        oidcDecodePayload.getSub(), oauthProvider.getValue());
-        return user.isEmpty();
+    public String getOauthLink(OauthProvider oauthProvider) {
+        OauthStrategy oauthStrategy = oauthFactory.getOauthstrategy(oauthProvider);
+        return oauthStrategy.getOauthLink();
     }
 
     public AvailableRegisterResponse getUserAvailableRegister(String token, OauthProvider oauthProvider) throws NoSuchAlgorithmException, InvalidKeySpecException {
@@ -174,5 +156,25 @@ public class CredentialService {
         return email != null ? email : schEmail;
     }
 
+    private String generateRefreshToken(Long userId) {
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
+        Long tokenExpiredAt = jwtTokenProvider.getRefreshTokenTTlSecond();
+        RefreshTokenRedisEntity build =
+                RefreshTokenRedisEntity.builder()
+                        .id(userId.toString())
+                        .ttl(tokenExpiredAt)
+                        .refreshToken(refreshToken)
+                        .build();
+        refreshTokenRedisEntityRepository.save(build);
+        return refreshToken;
+    }
+
+    private Boolean checkUserCanRegister(
+            OIDCDecodePayload oidcDecodePayload, OauthProvider oauthProvider) {
+        Optional<User> user =
+                userRepository.findByOauthIdAndOauthProvider(
+                        oidcDecodePayload.getSub(), oauthProvider.getValue());
+        return user.isEmpty();
+    }
 }
 

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/CredentialService.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/CredentialService.java
@@ -51,6 +51,12 @@ public class CredentialService {
         return oauthStrategy.getOauthLink();
     }
 
+    public AfterOauthResponse getTokenToCode(OauthProvider oauthProvider, String code) {
+        OauthStrategy oauthStrategy = oauthFactory.getOauthstrategy(oauthProvider);
+        OauthTokenInfoDto oauthToken = oauthStrategy.getOauthToken(code);
+        return new AfterOauthResponse(oauthToken.getIdToken(),oauthToken.getAccessToken());
+    }
+
     public AvailableRegisterResponse getUserAvailableRegister(String token, OauthProvider oauthProvider) throws NoSuchAlgorithmException, InvalidKeySpecException {
         OauthStrategy oauthstrategy = oauthFactory.getOauthstrategy(oauthProvider);
         OIDCDecodePayload oidcDecodePayload = oauthstrategy.getOIDCDecodePayload(token);

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/GoogleOauthStrategy.java
@@ -35,6 +35,23 @@ public class GoogleOauthStrategy implements OauthStrategy{
     }
 
     @Override
+    public OauthTokenInfoDto getOauthToken(String code) {
+        String decodedCode = URLDecoder.decode(code, StandardCharsets.UTF_8);
+
+        OauthTokenResponse oauthTokenResponse = googleAuthClient
+                .googleAuth(
+                        decodedCode,
+                        oauthProperties.getGoogleAppId(),
+                        oauthProperties.getGoogleClientSecret(),
+                        oauthProperties.getGoogleRedirectUrl());
+
+        return OauthTokenInfoDto.builder()
+                .idToken(oauthTokenResponse.getIdToken())
+                .accessToken(oauthTokenResponse.getAccessToken())
+                .build();
+    }
+
+    @Override
     public OIDCDecodePayload getOIDCDecodePayload(String token) {
         OIDCPublicKeysResponse oidcPublicKeysResponse = googleAuthClient.getGoogleOIDCOpenKeys();
         return oauthOIDCProvider.getPayloadFromIdToken(

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/GoogleOauthStrategy.java
@@ -1,10 +1,16 @@
 package ohsoontaxi.backend.domain.credential.service;
 
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import ohsoontaxi.backend.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 import ohsoontaxi.backend.global.api.client.GoogleAuthClient;
 import ohsoontaxi.backend.global.api.dto.OIDCPublicKeysResponse;
+import ohsoontaxi.backend.global.api.dto.OauthTokenResponse;
 import ohsoontaxi.backend.global.property.OauthProperties;
 import org.springframework.stereotype.Component;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 @AllArgsConstructor
 @Component("GOOGLE")
@@ -14,12 +20,24 @@ public class GoogleOauthStrategy implements OauthStrategy{
     private final GoogleAuthClient googleAuthClient;
     private final OauthOIDCProvider oauthOIDCProvider;
     private static final String ISSUER = "https://accounts.google.com";
+    private static final String QUERY_STRING =
+            "/o/oauth2/v2/auth?response_type=code&client_id=%s&scope=%s&redirect_uri=%s";
+    private static final String scope = "https://www.googleapis.com/auth/userinfo.email";
 
+    public String getOauthLink() {
+        return oauthProperties.getGoogleBaseUrl()
+                + String.format(
+                QUERY_STRING,
+                oauthProperties.getGoogleAppId(),
+                scope,
+                oauthProperties.getGoogleRedirectUrl());
+    }
+
+    @Override
     public OIDCDecodePayload getOIDCDecodePayload(String token) {
         OIDCPublicKeysResponse oidcPublicKeysResponse = googleAuthClient.getGoogleOIDCOpenKeys();
         return oauthOIDCProvider.getPayloadFromIdToken(
                 token, ISSUER, oauthProperties.getGoogleAppId(), oidcPublicKeysResponse);
     }
-
 }
 

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/GoogleOauthStrategy.java
@@ -24,6 +24,7 @@ public class GoogleOauthStrategy implements OauthStrategy{
             "/o/oauth2/v2/auth?response_type=code&client_id=%s&scope=%s&redirect_uri=%s";
     private static final String scope = "https://www.googleapis.com/auth/userinfo.email";
 
+    @Override
     public String getOauthLink() {
         return oauthProperties.getGoogleBaseUrl()
                 + String.format(

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/KaKaoOauthStrategy.java
@@ -2,8 +2,10 @@ package ohsoontaxi.backend.domain.credential.service;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import ohsoontaxi.backend.domain.credential.presentation.dto.response.OauthTokenInfoDto;
 import ohsoontaxi.backend.global.api.client.KakaoOauthClient;
 import ohsoontaxi.backend.global.api.dto.OIDCPublicKeysResponse;
+import ohsoontaxi.backend.global.api.dto.OauthTokenResponse;
 import ohsoontaxi.backend.global.property.OauthProperties;
 import org.springframework.stereotype.Component;
 
@@ -16,10 +18,20 @@ public class KaKaoOauthStrategy implements OauthStrategy{
     private final KakaoOauthClient kakaoOauthClient;
     private final OauthOIDCProvider oauthOIDCProvider;
     private static final String ISSUER = "https://kauth.kakao.com";
+    private static final String QUERY_STRING = "/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code";
 
+    public String getOauthLink() {
+        return oauthProperties.getKakaoBaseUrl()
+                + String.format(
+                QUERY_STRING,
+                oauthProperties.getKakaoClientId(),
+                oauthProperties.getKakaoRedirectUrl());
+    }
+
+    @Override
     public OIDCDecodePayload getOIDCDecodePayload(String token) {
-        OIDCPublicKeysResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys(); //@feign을 이용해서 공개키 배열 가져오기(keys 리스트)
+        OIDCPublicKeysResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
         return oauthOIDCProvider.getPayloadFromIdToken(
-                token, ISSUER, oauthProperties.getKakaoAppId(), oidcPublicKeysResponse); //id token 검증
+                token, ISSUER, oauthProperties.getKakaoAppId(), oidcPublicKeysResponse);
     }
 }

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/KaKaoOauthStrategy.java
@@ -30,6 +30,19 @@ public class KaKaoOauthStrategy implements OauthStrategy{
     }
 
     @Override
+    public OauthTokenInfoDto getOauthToken(String code) {
+        OauthTokenResponse oauthTokenResponse = kakaoOauthClient
+                .kakaoAuth(
+                        oauthProperties.getKakaoClientId(),
+                        oauthProperties.getKakaoRedirectUrl(),
+                        code);
+        return OauthTokenInfoDto.builder()
+                .idToken(oauthTokenResponse.getIdToken())
+                .accessToken(oauthTokenResponse.getAccessToken())
+                .build();
+    }
+
+    @Override
     public OIDCDecodePayload getOIDCDecodePayload(String token) {
         OIDCPublicKeysResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
         return oauthOIDCProvider.getPayloadFromIdToken(

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/KaKaoOauthStrategy.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/KaKaoOauthStrategy.java
@@ -20,6 +20,7 @@ public class KaKaoOauthStrategy implements OauthStrategy{
     private static final String ISSUER = "https://kauth.kakao.com";
     private static final String QUERY_STRING = "/oauth/authorize?client_id=%s&redirect_uri=%s&response_type=code";
 
+    @Override
     public String getOauthLink() {
         return oauthProperties.getKakaoBaseUrl()
                 + String.format(

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/OauthStrategy.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/OauthStrategy.java
@@ -1,8 +1,12 @@
 package ohsoontaxi.backend.domain.credential.service;
 
+import ohsoontaxi.backend.domain.credential.presentation.dto.response.OauthTokenInfoDto;
+
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 
 public interface OauthStrategy {
+    String getOauthLink();
+
     OIDCDecodePayload getOIDCDecodePayload(String token) throws NoSuchAlgorithmException, InvalidKeySpecException;
 }

--- a/src/main/java/ohsoontaxi/backend/domain/credential/service/OauthStrategy.java
+++ b/src/main/java/ohsoontaxi/backend/domain/credential/service/OauthStrategy.java
@@ -8,5 +8,7 @@ import java.security.spec.InvalidKeySpecException;
 public interface OauthStrategy {
     String getOauthLink();
 
+    OauthTokenInfoDto getOauthToken(String code);
+
     OIDCDecodePayload getOIDCDecodePayload(String token) throws NoSuchAlgorithmException, InvalidKeySpecException;
 }

--- a/src/main/java/ohsoontaxi/backend/global/api/client/GoogleAuthClient.java
+++ b/src/main/java/ohsoontaxi/backend/global/api/client/GoogleAuthClient.java
@@ -1,9 +1,13 @@
 package ohsoontaxi.backend.global.api.client;
 
+import feign.Headers;
 import ohsoontaxi.backend.global.api.dto.OIDCPublicKeysResponse;
+import ohsoontaxi.backend.global.api.dto.OauthTokenResponse;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @FeignClient(name = "GoogleAuthClient", url = "https://www.googleapis.com/oauth2")
 public interface GoogleAuthClient {
@@ -11,5 +15,14 @@ public interface GoogleAuthClient {
     @Cacheable(cacheNames = "GoogleOICD", cacheManager = "oidcCacheManager")
     @GetMapping("/v3/certs")
     OIDCPublicKeysResponse getGoogleOIDCOpenKeys();
+
+    @Headers("Content-type: application/x-www-form-urlencoded;charset=utf-8")
+    @PostMapping(
+            "/v4/token?code={CODE}&client_id={CLIENT_ID}&client_secret={CLIENT_SECRET}&redirect_uri={REDIRECT_URI}&grant_type=authorization_code")
+    OauthTokenResponse googleAuth(
+            @PathVariable("CODE") String code,
+            @PathVariable("CLIENT_ID") String clientId,
+            @PathVariable("CLIENT_SECRET") String client_secret,
+            @PathVariable("REDIRECT_URI") String redirectUri);
 }
 

--- a/src/main/java/ohsoontaxi/backend/global/api/client/KakaoOauthClient.java
+++ b/src/main/java/ohsoontaxi/backend/global/api/client/KakaoOauthClient.java
@@ -1,9 +1,13 @@
 package ohsoontaxi.backend.global.api.client;
 
+import feign.Headers;
 import ohsoontaxi.backend.global.api.dto.OIDCPublicKeysResponse;
+import ohsoontaxi.backend.global.api.dto.OauthTokenResponse;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @FeignClient(name = "KakaoAuthClient", url = "https://kauth.kakao.com")
 public interface KakaoOauthClient {
@@ -11,4 +15,12 @@ public interface KakaoOauthClient {
     @Cacheable(cacheNames = "KakaoOICD", cacheManager = "oidcCacheManager")
     @GetMapping("/.well-known/jwks.json")
     OIDCPublicKeysResponse getKakaoOIDCOpenKeys();
+
+    @Headers("Content-type: application/x-www-form-urlencoded;charset=utf-8")
+    @PostMapping(
+            "/oauth/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}")
+    OauthTokenResponse kakaoAuth(
+            @PathVariable("CLIENT_ID") String clientId,
+            @PathVariable("REDIRECT_URI") String redirectUri,
+            @PathVariable("CODE") String code);
 }

--- a/src/main/java/ohsoontaxi/backend/global/api/dto/OauthTokenResponse.java
+++ b/src/main/java/ohsoontaxi/backend/global/api/dto/OauthTokenResponse.java
@@ -1,0 +1,15 @@
+package ohsoontaxi.backend.global.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OauthTokenResponse {
+    @JsonProperty("id_token")
+    private String idToken;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,9 +56,15 @@ auth:
 oauth:
   kakao:
     app-id: ${KAKAO_APP_ID}
+    client-id: ${KAKAO_CLIENT_ID}
+    redirect-url: ${KAKAO_REDIRECT_URL}
+    base-url: ${KAKAO_BASE_URL}
 
   google:
     app-id: ${GOOGLE_APP_ID}
+    redirect-url: ${GOOGLE_REDIRECT_URL}
+    base-url: ${GOOGLE_BASE_URL}
+    client-secret : ${GOOGLE_CLIENT_SECRET}
 
 fcm:
   value: firebase_service_key.json


### PR DESCRIPTION
resolved : #146 

## 작업 내용
- 카카오, 구글 인가 코드 요청 URI 생성
- 인가 코드를 통해 카카오, 구글 서버에 accessToken, idToken 요청

## 전달 사항
- 회원 탈퇴 기능 추가 예정